### PR TITLE
Add emoji to README header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==========
-🚀 Bowtie
+🤝 Bowtie
 ==========
 
 .. image:: ./docs/_static/dreamed.png

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==========
-🦋 Bowtie
+🚀 Bowtie
 ==========
 
 .. image:: ./docs/_static/dreamed.png

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-======
-Bowtie
-======
+==========
+🎀 Bowtie
+==========
 
 .. image:: ./docs/_static/dreamed.png
   :alt: Bowtie

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==========
-🎀 Bowtie
+🦋 Bowtie
 ==========
 
 .. image:: ./docs/_static/dreamed.png

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==========
-🤝 Bowtie
+👔 Bowtie
 ==========
 
 .. image:: ./docs/_static/dreamed.png


### PR DESCRIPTION
Prefixes the top-level README title with a bowtie ribbon emoji (🎀).

The README currently has a single top-level RST header (`Bowtie`); this PR adds an emoji to it and adjusts the underline length to match RST's requirement that underlines be at least as long as the title text. Verified the file still parses cleanly with `docutils`.



<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1676.org.readthedocs.build/en/1676/

<!-- readthedocs-preview bowtie-json-schema end -->